### PR TITLE
feat(env vars): allow env vars to be used without quotes

### DIFF
--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiddler-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 exclude = ["tests"]
 license-file = "../LICENSE"
@@ -16,7 +16,7 @@ msrv = "1.74.1"
 [dependencies]
 async-trait = "0.1.79"
 clap = { version = "4.5.3", features = ["derive"] }
-fiddler = { version = "0.3.0", path = "../lib", features = ["all"] }
+fiddler = { version = "0.3.1", path = "../lib", features = ["all"] }
 futures = "0.3.30"
 inline_colorization = "0.1.6"
 prettytable-rs = "0.10.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiddler"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license-file = "../LICENSE"
 description = "Data Stream processor written in rust"
@@ -21,7 +21,7 @@ async-std = { version = "1.12.0", features = ["std"] }
 async-trait = "0.1.78"
 crossbeam-channel = "0.5.12"
 elasticsearch = { version = "8.5.0-alpha.1", features = ["rustls-tls"], optional = true }
-fiddler-macros = { version = "0.3.0", path = "../macros" }
+fiddler-macros = { version = "0.3.1", path = "../macros" }
 futures = "0.3.30"
 handlebars = { version = "5.1.2", features = ["no_logging"] }
 jmespath = "0.3.0"

--- a/lib/src/env/mod.rs
+++ b/lib/src/env/mod.rs
@@ -72,7 +72,7 @@ impl Environment {
         });
         trace!("plugins registered");
 
-        let conf: Config = serde_yaml::from_str(config)?;
+        let conf: Config = Config::from_str(config)?;
         let parsed_conf = conf.validate()?;
 
         debug!("environment is ready");

--- a/lib/src/env/mod.rs
+++ b/lib/src/env/mod.rs
@@ -8,6 +8,7 @@ use tracing::{debug, error, info, trace};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem;
+use std::str::FromStr;
 use std::sync::Once;
 use std::sync::{Arc, Mutex};
 use tokio::time::{sleep, Duration};
@@ -524,7 +525,7 @@ async fn decrease_active_count(message: &mut InternalMessage) -> Result<usize, E
             let mut lock = l.borrow_mut();
             *lock -= 1;
             trace!("message has {} copies to process", lock);
-            Ok(lock.clone())
+            Ok(*lock)
         }
         Err(_) => Err(Error::UnableToSecureLock),
     }

--- a/lib/tests/integration_test.rs
+++ b/lib/tests/integration_test.rs
@@ -317,7 +317,7 @@ pipeline:
 output:
   validate:
     expected: 
-      - {{ TestingEnvVarReplacement }}";
+      - ReplacementSuccessful";
 
     REGISTER.call_once(|| {
         mock::register_mock_input().unwrap();

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiddler-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license-file = "../LICENSE"
 description = "Macros for internal use of registering plugins in fiddler"


### PR DESCRIPTION
Since yaml conversion was happening before template replacement, variables used like `this: {{ value }}` would fail the yaml formatting; but `this: '{{ value }}'` would not.  Moved replacement of env vars prior to yaml conversion and enabled strict mode so missing variables will cause validation errors.  A future iteration may make this validation optional for linting.